### PR TITLE
Allow `setIn` to automatically create arrays.

### DIFF
--- a/src/timm.js
+++ b/src/timm.js
@@ -291,7 +291,8 @@ export function getIn(
 // -- // true
 // -- ```
 export function set<T>(obj: ?T, key: Key, val: any): T {
-  const finalObj: any = obj == null ? {} : obj;
+  const fallback = Number.isInteger(key) ? [] : {};
+  const finalObj: any = obj == null ? fallback : obj;
   if (finalObj[key] === val) return finalObj;
   const obj2 = clone(finalObj);
   obj2[key] = val;

--- a/test/objects.js
+++ b/test/objects.js
@@ -126,6 +126,13 @@ test('setIn: should create nested objects for unknown paths', (t) => {
   t.is(obj2.unknown.long.path, 3);
 });
 
+test('setIn: should create nested arrays for unknown paths with integer segments', (t) => {
+  const obj2 = timm.setIn(OBJ, ['unknown', 0, 'long', 1, 'path'], 'value');
+  t.truthy(Array.isArray(obj2.unknown));
+  t.truthy(Array.isArray(obj2.unknown[0].long));
+  t.is(obj2.unknown[0].long[1].path, 'value');
+});
+
 test('setIn: should return the value if the path is empty', (t) => {
   const obj2 = timm.setIn(OBJ, [], { a: 3 });
   t.deepEqual(obj2, { a: 3 });


### PR DESCRIPTION
Today, if you use `setIn` where a path segment includes an integer, timm creates an intermediate object rather than an array:

```js
timm.setIn({}, ['foo', 0, 'bar'], 'value'); // => { foo: { '0': { bar: 'value' } } }
```

This PR updates `set` (and therefore `setIn`) to create an array rather than an object if the new key is an integer:

```js
timm.setIn({}, ['foo', 0, 'bar'], 'value'); // => { foo: [ { bar: 'value' } ] }
```
