### PR TITLE
Add mergeDeep function

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,39 @@ merge(obj1, { c: 3 }) === obj1
 // true
 ```
 
+#### mergeDeep()
+Returns a new object built as follows: the overlapping keys from the
+second one overwrite the corresponding entries from the first one.
+If both the first and second entries are objects they are merged recursively.
+Similar to `Object.assign()`, but immutable, and deeply merging.
+
+Usage:
+
+* `mergeDeep(obj1: Object, obj2: ?Object): Object`
+* `mergeDeep(obj1: Object, ...objects: Array<?Object>): Object`
+
+The unmodified `obj1` is returned if `obj2` does not *provide something
+new to* `obj1`, i.e. if either of the following
+conditions are true:
+
+* `obj2` is `null` or `undefined`
+* `obj2` is an object, but it is empty
+* All attributes of `obj2` are referentially equal to the
+  corresponding attributes of `obj`
+
+```js
+obj1 = { a: 1, b: 2, c: { a: 1 } }
+obj2 = { b: 3, c: { b: 2 } }
+obj3 = mergeDeep(obj1, obj2)
+// { a: 1, b: 3, c: { a: 1, b: 2 }  }
+obj3 === obj1
+// false
+
+// The same object is returned if there are no changes:
+mergeDeep(obj1, { c: { a: 1 } }) === obj1
+// true
+```
+
 #### mergeIn()
 Similar to `merge()`, but merging the value at a given nested path.
 Note that the returned type is the same as that of the first argument.

--- a/src/api.js.flow
+++ b/src/api.js.flow
@@ -17,6 +17,7 @@ declare export var setIn: typeof(timm.setIn);
 declare export var update: typeof(timm.update);
 declare export var updateIn: typeof(timm.updateIn);
 declare export var merge: typeof(timm.merge);
+declare export var mergeDeep: typeof(timm.mergeDeep);
 declare export var mergeIn: typeof(timm.mergeIn);
 declare export var omit: typeof(timm.omit);
 declare export var addDefaults: typeof(timm.addDefaults);

--- a/test/objects.js
+++ b/test/objects.js
@@ -311,6 +311,35 @@ test('merge: multiple: should return the same object when it hasn\'t changed', (
 });
 
 //------------------------------------------------
+// mergeDeep()
+//------------------------------------------------
+test('mergeDeep: should merge deeply', (t) => {
+  const obj2 = timm.mergeDeep({ a: 1, b: { a: 1, b:2 } }, { b: { b: 3 } });
+  t.deepEqual(obj2, { a: 1, b: { a: 1, b: 3 } });
+});
+
+test('mergeDeep: multiple: should merge deeply', (t) => {
+  const obj2 = timm.mergeDeep({ a: 1, b: { a: 1, b: 1 } }, { b: { b: 2, c: 2 } }, { a: 3, b: { c: 3 } });
+  t.deepEqual(obj2, { a: 3, b: { a: 1, b: 2, c:3 } });
+});
+
+test('mergeDeep: should return the same object when it hasn\'t changed', (t) => {
+  const obj1 = { a: 1, b: { a: 1, b: 2 }};
+  const obj2 = timm.mergeDeep(obj1, { a: 1, b: {} }, {a: 1, b: obj1.b });
+  t.is(obj1, obj2);
+});
+
+test('mergeDeep: multiple: should return the same object when it hasn\'t changed', (t) => {
+  const obj2 = timm.mergeDeep(OBJ, { b: 2 }, { d: { b: OBJ.d.b } }, { c: undefined });
+  t.is(obj2, OBJ);
+});
+
+test('mergeDeep: with more than 6 args', (t) => {
+  const obj2 = timm.mergeDeep({ a: 1 }, { b: { a: 1 } }, { c: 3 }, { d: 4 }, { e: 5 }, { f: 6 }, { b: { b: 2 } });
+  t.deepEqual(obj2, { a: 1, b: { a: 1, b: 2 }, c: 3, d: 4, e: 5, f: 6 });
+});
+
+//------------------------------------------------
 // mergeIn()
 //------------------------------------------------
 test('mergeIn: with changes', (t) => {


### PR DESCRIPTION
This PR adds a `mergeDeep` function to timm.

I recently replaced seamless-immutable with timm in a project, which gave a nice perfomance boost :) The only thing missing when making the transition was a way to merge deeply (I used Lodash's `merge({}, obj1, obj2)` as a temporary solution, but that obviously isn't ideal since it always creates a new object).

From what I can tell when running the benchmarks on this branch vs master, adding this had no measurable impact on performance for the regular merge.