### PR TITLE
doSetIn: ensure nested value is object

### DIFF
--- a/src/timm.js
+++ b/src/timm.js
@@ -369,7 +369,7 @@ function doSetIn<T: ArrayOrObject>(
   if (idx === path.length - 1) {
     newValue = val;
   } else {
-    const nestedObj = isObject(obj)
+    const nestedObj = isObject(obj) && isObject(obj[key])
       ? obj[key]
       : typeof path[idx + 1] === 'number' ? [] : {};
     newValue = doSetIn(nestedObj, path, val, idx + 1);


### PR DESCRIPTION
This fixes an issue with `setIn` where an exception is thrown in IE11.

Steps to reproduce:

- Open https://jsfiddle.net/dty6t8vc/1/ in IE 11

Code:

```js
var obj = {foo: ''};
var newObj = timm.setIn(obj, ['foo', 'bar'], 'baz');
```

- Open console
- Click 'run'.


What ends up happening, before this patch, is local variable [`nestedObj`](https://github.com/guigrpa/timm/blob/master/src/timm.js#L372) in the `doSetIn` function (which in the jsfiddle example, is an empty string), and it gets passed to the `clone` function, which uses the `Object.keys` API. In IE 11, when `Object.keys` is called with something other than an object, an exception is thrown, as shown below:

<img width="1226" alt="screen shot 2017-12-28 at 4 43 09 pm" src="https://user-images.githubusercontent.com/1571918/34426706-54c3f88a-ebee-11e7-8f0d-ad6d938a4cde.png">

With this patch, the expected behavior occurs in IE 11 and newObj is `{"foo":{"bar":"baz"}}`.