### PR TITLE
Typescript definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.2",
   "description": "Immutability helpers with fast reads and acceptable writes",
   "main": "lib/timm.js",
+  "types": "lib/timm.d.ts",
   "dependencies": {},
   "devDependencies": {
     "ava": "0.16.0",
@@ -48,7 +49,7 @@
     "testCovProd": "cross-env NODE_ENV=production nyc ava && mv .nyc_output/* .nyc_tmp/",
     "testCovMin": "cross-env TEST_MINIFIED_LIB=1 nyc ava && mv .nyc_output/* .nyc_tmp/",
     "testCovReport": "cp .nyc_tmp/* .nyc_output/ && nyc report --reporter=html --reporter=lcov",
-    "compile": "rm -rf ./lib && mkdir lib && babel -o lib/timm.js src/timm.js && cp src/api.js.flow lib/timm.js.flow",
+    "compile": "rm -rf ./lib && mkdir lib && babel -o lib/timm.js src/timm.js && cp src/api.js.flow lib/timm.js.flow && cp src/timm.d.ts lib/timm.d.ts",
     "docs": "extract-docs --template docs/README_TEMPLATE.md --output README.md",
     "uglify": "cross-env NODE_ENV=production envify lib/timm.js | uglifyjs - -o lib/timm.min.js --mangle --compress --comments \"/^!/\"",
     "build": "yarn lint && yarn flow && yarn compile && yarn uglify && yarn testCovFull && yarn docs && yarn xxl",

--- a/src/timm.d.ts
+++ b/src/timm.d.ts
@@ -18,8 +18,8 @@ declare module 'timm' {
     idx: number,
     newItem: T
   ): Array<T>
-  export function getIn(obj: ?ArrayOrObject, path: Array<Key>): any
-  export function set<T> (obj: ?T, key: Key, val: any): T
+  export function getIn(obj: ArrayOrObject | undefined, path: Array<Key>): any
+  export function set<T> (obj: T | undefined, key: Key, val: any): T
   export function setIn<T = ArrayOrObject> (obj: T, path: Array<Key>, val: any): T
   export function update<T = ArrayOrObject> (
     obj: T,
@@ -49,7 +49,7 @@ declare module 'timm' {
     f?: Object,
     ...rest: Array<Object>
   ): Object
-  export function mergeIn<T: ArrayOrObject> (
+  export function mergeIn<T = ArrayOrObject> (
     a: T,
     path: Array<Key>,
     b?: Object,

--- a/src/timm.d.ts
+++ b/src/timm.d.ts
@@ -1,0 +1,72 @@
+declare module 'timm' {
+  type ArrayOrObject = Array<any> | Object;
+  type Key = number | string;
+
+  export function clone<T = ArrayOrObject> (obj: T): T
+  export function addLast<T> (array: Array<T>, val: Array<T> | T): Array<T>
+  export function addFirst<T> (array: Array<T>, val: Array<T> | T): Array<T>
+  export function removeLast<T> (array: Array<T>): Array<T>
+  export function removeFirst<T> (array: Array<T>): Array<T>
+  export function insert<T>(
+    array: Array<T>,
+    idx: number,
+    val: Array<T> | T
+  ): Array<T>
+  export function removeAt<T> (array: Array<T>, idx: number): Array<T>
+  export function replaceAt<T>(
+    array: Array<T>,
+    idx: number,
+    newItem: T
+  ): Array<T>
+  export function getIn(obj: ?ArrayOrObject, path: Array<Key>): any
+  export function set<T> (obj: ?T, key: Key, val: any): T
+  export function setIn<T = ArrayOrObject> (obj: T, path: Array<Key>, val: any): T
+  export function update<T = ArrayOrObject> (
+    obj: T,
+    key: Key,
+    fnUpdate: (prevValue: any) => any
+  ): T
+  export function updateIn<T = ArrayOrObject> (
+    obj: T,
+    path: Array<Key>,
+    fnUpdate: (prevValue: any) => any
+  ): T
+  export function merge(
+    a: Object,
+    b?: Object,
+    c?: Object,
+    d?: Object,
+    e?: Object,
+    f?: Object,
+    ...rest: Array<Object>
+  ): Object
+  export function mergeDeep(
+    a: Object,
+    b?: Object,
+    c?: Object,
+    d?: Object,
+    e?: Object,
+    f?: Object,
+    ...rest: Array<Object>
+  ): Object
+  export function mergeIn<T: ArrayOrObject> (
+    a: T,
+    path: Array<Key>,
+    b?: Object,
+    c?: Object,
+    d?: Object,
+    e?: Object,
+    f?: Object,
+    ...rest: Array<Object>
+  ): T
+  export function omit(obj: Object, attrs: Array<string> | string): Object
+  export function addDefaults(
+    a: Object,
+    b?: Object,
+    c?: Object,
+    d?: Object,
+    e?: Object,
+    f?: Object,
+    ...rest: Array<Object>
+  ): Object
+}


### PR DESCRIPTION
Added a typescript definition for timm's public interface, ported from the `.flow` definition. Copies the `.d.ts` into `lib` on build (like the flow one), and adds `"types"` to `package.json` as per [the TypeScript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)

I haven't tested pulling this down into our project yet (via `build` + `npm link`) but can confirm the types work as intended.