### PR TITLE
always overwrite functions

### DIFF
--- a/src/timm.js
+++ b/src/timm.js
@@ -81,7 +81,7 @@ function doMerge(
 
 function isObject(o: any): boolean {
   const type = typeof o;
-  return o != null && (type === 'object' || type === 'function');
+  return o != null && type === 'object';
 }
 
 // _deepFreeze = (obj) ->

--- a/test/objects.js
+++ b/test/objects.js
@@ -390,6 +390,14 @@ test('mergeDeep: with more than 6 args', t => {
   t.deepEqual(obj2, { a: 1, b: { a: 1, b: 2 }, c: 3, d: 4, e: 5, f: 6 });
 });
 
+test('mergeDeep: should overwrite functions', t => {
+  const obj = timm.mergeDeep(
+    { fn: () => 'first' },
+    { fn: () => 'second' }
+  );
+  t.is(obj.fn(), 'second');
+});
+
 test('merge: should preserve unmodified Symbols', t => {
   const obj2 = timm.merge(OBJ, { foo: 'bar' });
   t.is(obj2[SYMBOL], OBJ[SYMBOL]);


### PR DESCRIPTION
Previously `timm` would try to `mergeDeep` on functions. This resulted in the original function being in the new object rather than the one I was trying to overwrite with. 

This change makes it so that when `timm` encounters a function it just uses the new function, rather than trying to merge them.

closes #24 