### PR TITLE
chore: fix repository field and add homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "keywords": [
     "immutability"
   ],
+  "homepage": "http://guigrpa.github.io/timm/",
   "repository": {
     "type": "git",
-    "url": "http://github.com/guigrpa/timm"
+    "url": "https://github.com/guigrpa/timm.git"
   },
   "main": "lib/timm.js",
   "types": "lib/timm.d.ts",


### PR DESCRIPTION
I added the old url (which is still the url in the registry) to the "homepage" field and used the proper https url for the repository url (as git clone to the http url will give `warning: redirecting to https://github.com/guigrpa/timm/`.

I discovered this issue cuz I have a script that does
```zsh
» type -f npm-clone
npm-clone () {
	git clone "$(npm info --json "$1"|jq -r '(.repository.url // .repository)' | sed 's/^git+http/http/')" "$1"
}
```