### PR TITLE
fix: ie11 support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    ['@babel/env', { targets: { node: 'current' } }],
+    '@babel/env',
     '@babel/typescript',
   ],
   plugins: [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "lib",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "target": "ES5"
   },
   "exclude": ["src/typeTests.ts"],
   "include": ["src/**/*"]


### PR DESCRIPTION
Release v1.7.0 introduced ES2015+ syntax (e.g, usage of the spread operator) led to a regression with older browsers (e.g., IE 11). Example of this in the `merge` function:

<img width="973" alt="Screen Shot 2021-06-26 at 5 36 17 PM" src="https://user-images.githubusercontent.com/1571918/123529449-2b56f880-d6a5-11eb-95dc-90bad6ca70f6.png">

<img width="973" alt="Screen Shot 2021-06-26 at 5 36 30 PM" src="https://user-images.githubusercontent.com/1571918/123529452-2e51e900-d6a5-11eb-922e-7454927d57a5.png">

This is fixed by remove targets from babel-env:

> Since one of the original goals of preset-env was to help users easily transition from using preset-latest, it behaves similarly when no targets are specified: preset-env will transform all ES2015-ES2020 code to be ES5 compatible.

https://babeljs.io/docs/en/babel-preset-env
